### PR TITLE
Hey LouisRemi! Thanks for the hard work, please accept this fix

### DIFF
--- a/jquery.transition.js
+++ b/jquery.transition.js
@@ -611,9 +611,10 @@ jQuery.extend( jQuery.fx.prototype, {
 			options = this.options,
 			// ++TRANSITION++
 			transition = options.transition[ this.prop ],
-			supportTransition;
+			supportTransition,
+			durationReached = t >= options.duration + this.startTime;
 
-		if ( transition || gotoEnd || t >= options.duration + this.startTime ) {
+		if ( transition || gotoEnd ||  durationReached) {
 			if ( !transition ) {
 				this.now = this.end;
 				this.pos = this.state = 1;
@@ -676,7 +677,7 @@ jQuery.extend( jQuery.fx.prototype, {
 				// we must ensure it won't be called twice. #5684
 
 				complete = options.complete;
-				if ( complete && gotoEnd ) {
+				if ( complete && (gotoEnd || durationReached) ) {
 
 					options.complete = false;
 					complete.call( elem );

--- a/jquery.transition.js
+++ b/jquery.transition.js
@@ -676,7 +676,7 @@ jQuery.extend( jQuery.fx.prototype, {
 				// we must ensure it won't be called twice. #5684
 
 				complete = options.complete;
-				if ( complete ) {
+				if ( complete && gotoEnd ) {
 
 					options.complete = false;
 					complete.call( elem );


### PR DESCRIPTION
As per jQuery API, stop method called without the gotoEnd parameter
should not fire the onComplete callback of the queue.

I think this one line fix should resolve the problem.

Again thanks for your hard work!
